### PR TITLE
Fix crash when getUserPlaylists is called with no userId

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -636,8 +636,8 @@ var SpotifyWebApi = (function() {
       requestData = {
         url: _baseUri + '/me/playlists'
       };
-      options = userId;
       callback = options;
+      options = userId;
     }
     return _checkParamsAndPerformRequest(requestData, options, callback);
   };


### PR DESCRIPTION
Two assignments were called in the wrong order.  The options object ends up assigned to "callback", causing a crash later when the callback is run.
